### PR TITLE
aggiornata la funzione per entrare in una singola riga

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,4 @@
 * @param { boolean } expression the boolean value
 * @returns { boolean } the opposite of the value
 */
-export function not(expression: boolean): boolean {
-    if (expression == true) {
-        return false
-    }
-    else if (expression == false) {
-        return true
-    }
-    else {
-        throw new TypeError("Invalid Expression!")
-    }
-}
+export function not(expression: boolean) return !expression;


### PR DESCRIPTION
Ho aggiornato la funzione per entrare in una singola riga utilizzando l'operatore logico [NOT](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT)

Inoltre ho rimosso il ritorno esplicito dalla funzione perche' TypeScript lo fa gia' da solo.
Ho rimosso anche il TypeError, perche' TypeScript lo fa da solo. Inoltre il tuo TypeError non avrebbe funzionato in ogni caso perche' avresti dovuto usare [typeof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof).